### PR TITLE
Integrate telemetry system

### DIFF
--- a/src/connectivity/connectivity.c
+++ b/src/connectivity/connectivity.c
@@ -1,0 +1,65 @@
+#include "connectivity.h"
+#include "wifi_manager/wifi_manager.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/event_groups.h"
+#include "lwip/sockets.h"
+#include "lwip/inet.h"
+#include "esp_log.h"
+#include "telemetry_config.h"
+
+static const char *TAG = "conn_check";
+
+static bool connectivity_test(void)
+{
+    struct sockaddr_in dest = {0};
+    dest.sin_family = AF_INET;
+    dest.sin_port = htons(CONNECTIVITY_TEST_PORT);
+    dest.sin_addr.s_addr = inet_addr(CONNECTIVITY_TEST_IP);
+
+    int sock = socket(AF_INET, SOCK_STREAM, 0);
+    if (sock < 0) {
+        ESP_LOGE(TAG, "Socket creation failed");
+        return false;
+    }
+
+    int err = connect(sock, (struct sockaddr *)&dest, sizeof(dest));
+    close(sock);
+    return (err == 0);
+}
+
+void connectivity_monitor_task(void *pvParameters)
+{
+    (void)pvParameters;
+    EventGroupHandle_t eg = wifi_event_group();
+    int fails = 0;
+
+    while (1) {
+        xEventGroupWaitBits(eg, WIFI_CONNECTED_BIT, pdFALSE, pdTRUE, portMAX_DELAY);
+        vTaskDelay(pdMS_TO_TICKS(CONNECTIVITY_CHECK_INTERVAL_MS));
+
+        if (connectivity_test()) {
+            if (fails != 0) {
+                ESP_LOGI(TAG, "Connectivity restored after %d failed attempt%s", fails, (fails == 1 ? "" : "s"));
+            }
+            fails = 0;
+        } else {
+            ++fails;
+            int remaining = CONNECTIVITY_FAIL_THRESHOLD - fails;
+            ESP_LOGW(TAG,
+                     "Connectivity test failed (%d/%d). %d try%s left before forcing Wi-Fi reconnect",
+                     fails,
+                     CONNECTIVITY_FAIL_THRESHOLD,
+                     remaining,
+                     (remaining == 1 ? "" : "s"));
+            if (fails >= CONNECTIVITY_FAIL_THRESHOLD) {
+                fails = 0;
+                ESP_LOGW(TAG,
+                         "No connectivity after %d attempts — forcing Wi-Fi reconnect now",
+                         CONNECTIVITY_FAIL_THRESHOLD);
+                wifi_force_reconnect();
+                vTaskDelay(pdMS_TO_TICKS(1000));
+            }
+        }
+    }
+}

--- a/src/connectivity/connectivity.h
+++ b/src/connectivity/connectivity.h
@@ -1,0 +1,6 @@
+#ifndef CONNECTIVITY_H
+#define CONNECTIVITY_H
+
+void connectivity_monitor_task(void *pvParameters);
+
+#endif // CONNECTIVITY_H

--- a/src/mqtt_sender/mqtt_sender.c
+++ b/src/mqtt_sender/mqtt_sender.c
@@ -1,0 +1,113 @@
+#include "mqtt_sender.h"
+#include "wifi_manager/wifi_manager.h"
+#include "telemetry_config.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+#include "esp_log.h"
+#include "mqtt_client.h"
+#include "driver/twai.h"
+
+static const char *TAG = "mqtt_sender";
+static bool mqtt_connected;
+
+#if USE_MQTT
+const char mqtt_root_ca_pem[] =
+"-----BEGIN CERTIFICATE-----\n"
+"MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw\n"
+"TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh\n"
+"cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMTUwNjA0MTEwNDM4\n"
+"WhcNMzUwNjA0MTEwNDM4WjBPMQswCQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJu\n"
+"ZXQgU2VjdXJpdHkgUmVzZWFyY2ggR3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBY\n"
+"MTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAK3oJHP0FDfzm54rVygc\n"
+"h77ct984kIxuPOZXoHj3dcKi/vVqbvYATyjb3miGbESTtrFj/RQSa78f0uoxmyF+\n"
+"0TM8ukj13Xnfs7j/EvEhmkvBioZxaUpmZmyPfjxwv60pIgbz5MDmgK7iS4+3mX6U\n"
+"A5/TR5d8mUgjU+g4rk8Kb4Mu0UlXjIB0ttov0DiNewNwIRt18jA8+o+u3dpjq+sW\n"
+"T8KOEUt+zwvo/7V3LvSye0rgTBIlDHCNAymg4VMk7BPZ7hm/ELNKjD+Jo2FR3qyH\n"
+"B5T0Y3HsLuJvW5iB4YlcNHlsdu87kGJ55tukmi8mxdAQ4Q7e2RCOFvu396j3x+UC\n"
+"B5iPNgiV5+I3lg02dZ77DnKxHZu8A/lJBdiB3QW0KtZB6awBdpUKD9jf1b0SHzUv\n"
+"KBds0pjBqAlkd25HN7rOrFleaJ1/ctaJxQZBKT5ZPt0m9STJEadao0xAH0ahmbWn\n"
+"OlFuhjuefXKnEgV4We0+UXgVCwOPjdAvBbI+e0ocS3MFEvzG6uBQE3xDk3SzynTn\n"
+"jh8BCNAw1FtxNrQHusEwMFxIt4I7mKZ9YIqioymCzLq9gwQbooMDQaHWBfEbwrbw\n"
+"qHyGO0aoSCqI3Haadr8faqU9GY/rOPNk3sgrDQoo//fb4hVC1CLQJ13hef4Y53CI\n"
+"rU7m2Ys6xt0nUW7/vGT1M0NPAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNV\n"
+"HRMBAf8EBTADAQH/MB0GA1UdDgQWBBR5tFnme7bl5AFzgAiIyBpY9umbbjANBgkq\n"
+"hkiG9w0BAQsFAAOCAgEAVR9YqbyyqFDQDLHYGmkgJykIrGF1XIpu+ILlaS/V9lZL\n"
+"ubhzEFnTIZd+50xx+7LSYK05qAvqFyFWhfFQDlnrzuBZ6brJFe+GnY+EgPbk6ZGQ\n"
+"3BebYhtF8GaV0nxvwuo77x/Py9auJ/GpsMiu/X1+mvoiBOv/2X/qkSsisRcOj/KK\n"
+"NFtY2PwByVS5uCbMiogziUwthDyC3+6WVwW6LLv3xLfHTjuCvjHIInNzktHCgKQ5\n"
+"ORAzI4JMPJ+GslWYHb4phowim57iaztXOoJwTdwJx4nLCgdNbOhdjsnvzqvHu7Ur\n"
+"TkXWStAmzOVyyghqpZXjFaH3pO3JLF+l+/+sKAIuvtd7u+Nxe5AW0wdeRlN8NwdC\n"
+"jNPElpzVmbUq4JUagEiuTDkHzsxHpFKVK7q4+63SM1N95R1NbdWhscdCb+ZAJzVc\n"
+"oyi3B43njTOQ5yOf+1CceWxG1bQVs5ZufpsMljq4Ui0/1lvh+wjChP4kqKOJ2qxq\n"
+"4RgqsahDYVvTH9w7jXbyLeiNdd8XM2w9U/t7y0Ff/9yi0GE44Za4rF2LN9d11TPA\n"
+"mRGunUHBcnWEvgJBQl9nJEiU0Zsnvgc/ubhPgXRR4Xq37Z0j4r7g1SgEEzwxA57d\n"
+"emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=\n"
+"-----END CERTIFICATE-----\n";
+#endif
+
+static void mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_t event_id, void *event_data)
+{
+    switch (event_id) {
+        case MQTT_EVENT_CONNECTED:
+            mqtt_connected = true;
+            ESP_LOGI(TAG, "MQTT connected");
+            break;
+        case MQTT_EVENT_DISCONNECTED:
+            mqtt_connected = false;
+            ESP_LOGW(TAG, "MQTT disconnected");
+            break;
+        default:
+            break;
+    }
+}
+
+void mqtt_sender_task(void *pvParameters)
+{
+#if USE_MQTT
+    QueueHandle_t queue = (QueueHandle_t)pvParameters;
+    EventGroupHandle_t eg = wifi_event_group();
+    xEventGroupWaitBits(eg, WIFI_CONNECTED_BIT, pdFALSE, pdTRUE, portMAX_DELAY);
+
+    esp_mqtt_client_config_t cfg = {
+        .broker.address.uri = MQTT_URI,
+        .credentials.username = MQTT_USER,
+        .credentials.authentication.password = MQTT_PASS,
+        .broker.verification.certificate = mqtt_root_ca_pem,
+        .broker.verification.certificate_len = sizeof(mqtt_root_ca_pem)
+    };
+    esp_mqtt_client_handle_t client = esp_mqtt_client_init(&cfg);
+    esp_mqtt_client_register_event(client, ESP_EVENT_ANY_ID, mqtt_event_handler, NULL);
+    esp_mqtt_client_start(client);
+
+    twai_message_t current, newer;
+    int len = sizeof(twai_message_t);
+    bool warned = false;
+    while (1) {
+        if (xQueueReceive(queue, &current, portMAX_DELAY) != pdTRUE) {
+            ESP_LOGE(TAG, "Queue receive failed");
+            continue;
+        }
+        if (xQueueReceive(queue, &newer, 0) == pdTRUE)
+            current = newer;
+
+        if ((xEventGroupGetBits(eg) & WIFI_CONNECTED_BIT) == 0 || !mqtt_connected) {
+            if (!warned) {
+                ESP_LOGW(TAG, "MQTT not connected, waiting...");
+                warned = true;
+            }
+            xEventGroupWaitBits(eg, WIFI_CONNECTED_BIT, pdFALSE, pdTRUE, portMAX_DELAY);
+            while (!mqtt_connected) {
+                vTaskDelay(pdMS_TO_TICKS(100));
+            }
+            warned = false;
+            continue;
+        }
+        esp_mqtt_client_publish(client, MQTT_PUB_TOPIC, (const char *)&current, len, 0, 0);
+        vTaskDelay(pdMS_TO_TICKS(10));
+    }
+#else
+    (void)pvParameters;
+    ESP_LOGW(TAG, "MQTT support disabled, task exiting");
+    vTaskDelete(NULL);
+#endif
+}

--- a/src/mqtt_sender/mqtt_sender.h
+++ b/src/mqtt_sender/mqtt_sender.h
@@ -1,0 +1,6 @@
+#ifndef MQTT_SENDER_H
+#define MQTT_SENDER_H
+
+void mqtt_sender_task(void *pvParameters);
+
+#endif // MQTT_SENDER_H

--- a/src/telemetry_config.h
+++ b/src/telemetry_config.h
@@ -1,0 +1,22 @@
+#ifndef TELEMETRY_CONFIG_H
+#define TELEMETRY_CONFIG_H
+
+#define SERVER_IP "41.238.164.247"
+#define SERVER_PORT 19132
+
+#define USE_MQTT 1
+
+#if USE_MQTT
+#define MQTT_URI       "mqtts://5aeaff002e7c423299c2d92361292d54.s1.eu.hivemq.cloud:8883"
+#define MQTT_USER      "yousef"
+#define MQTT_PASS      "Yousef123"
+#define MQTT_PUB_TOPIC "com/yousef/esp32/data"
+extern const char mqtt_root_ca_pem[];
+#endif
+
+#define CONNECTIVITY_TEST_IP "8.8.8.8"
+#define CONNECTIVITY_TEST_PORT 53
+#define CONNECTIVITY_CHECK_INTERVAL_MS 1000
+#define CONNECTIVITY_FAIL_THRESHOLD 3
+
+#endif // TELEMETRY_CONFIG_H

--- a/src/udp_sender/udp_sender.c
+++ b/src/udp_sender/udp_sender.c
@@ -1,0 +1,179 @@
+#include "udp_sender.h"
+#include "wifi_manager/wifi_manager.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+#include "freertos/semphr.h"
+#include "lwip/sockets.h"
+#include "lwip/inet.h"
+#include "esp_log.h"
+#include "esp_heap_caps.h"
+#include "telemetry_config.h"
+#include "driver/twai.h"
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+
+static const char *TAG = "udp_sender";
+static int udp_sock = -1;
+static struct sockaddr_in dest_addr;
+static SemaphoreHandle_t udp_mutex = NULL;
+
+#define WIFI_SEND_ERR 118
+#define UDP_MAX_RETRIES    4
+#define UDP_BASE_DELAY_MS 10
+
+static uint32_t heap_log_counter = 0;
+
+static bool init_udp_socket(void) {
+    if (!udp_mutex) {
+        udp_mutex = xSemaphoreCreateMutex();
+        if (!udp_mutex) {
+            ESP_LOGE(TAG, "Failed to create UDP mutex");
+            return false;
+        }
+    }
+
+    xSemaphoreTake(udp_mutex, portMAX_DELAY);
+
+    if (udp_sock >= 0) {
+        close(udp_sock);
+    }
+
+    udp_sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
+    if (udp_sock < 0) {
+        int err = errno;
+        xSemaphoreGive(udp_mutex);
+        ESP_LOGE(TAG, "socket() failed: errno %d", err);
+        return false;
+    }
+
+    memset(&dest_addr, 0, sizeof(dest_addr));
+    dest_addr.sin_family      = AF_INET;
+    dest_addr.sin_port        = htons(SERVER_PORT);
+    dest_addr.sin_addr.s_addr = inet_addr(SERVER_IP);
+
+    xSemaphoreGive(udp_mutex);
+    return true;
+}
+
+void udp_socket_close(void) {
+    if (!udp_mutex) {
+        udp_mutex = xSemaphoreCreateMutex();
+        if (!udp_mutex) {
+            ESP_LOGE(TAG, "Failed to create UDP mutex");
+            if (udp_sock >= 0) {
+                close(udp_sock);
+                udp_sock = -1;
+            }
+            return;
+        }
+    }
+
+    xSemaphoreTake(udp_mutex, portMAX_DELAY);
+
+    if (udp_sock >= 0) {
+        close(udp_sock);
+        udp_sock = -1;
+        ESP_LOGI(TAG, "UDP socket closed due to Wi-Fi drop");
+    }
+
+    xSemaphoreGive(udp_mutex);
+}
+
+void udp_sender_task(void *pvParameters)
+{
+    QueueHandle_t queue = (QueueHandle_t)pvParameters;
+    EventGroupHandle_t eg = wifi_event_group();
+    xEventGroupWaitBits(eg,
+                        WIFI_CONNECTED_BIT,
+                        pdFALSE,
+                        pdTRUE,
+                        portMAX_DELAY);
+    ESP_LOGI(TAG, "Wi-Fi connected; starting UDP sender");
+
+    if (!init_udp_socket()) {
+        ESP_LOGE(TAG, "Initial UDP socket setup failed");
+        vTaskDelete(NULL);
+        return;
+    }
+
+    twai_message_t current, newer;
+    int len = sizeof(twai_message_t);
+
+    while (1) {
+        if (xQueueReceive(queue, &current, portMAX_DELAY) != pdTRUE) {
+            ESP_LOGE(TAG, "Queue receive failed");
+            continue;
+        }
+
+        if ((xEventGroupGetBits(eg) & WIFI_CONNECTED_BIT) == 0) {
+            ESP_LOGW(TAG, "Wi-Fi lost, waiting to reconnect...");
+            xEventGroupWaitBits(eg,
+                                WIFI_CONNECTED_BIT,
+                                pdFALSE,
+                                pdTRUE,
+                                portMAX_DELAY);
+            ESP_LOGI(TAG, "Wi-Fi reconnected; re-initializing socket");
+            init_udp_socket();
+        }
+
+        bool sent = false;
+        int last_err = 0;
+        for (int attempt = 1; attempt <= UDP_MAX_RETRIES; ++attempt) {
+            if (xQueueReceive(queue, &newer, 0) == pdTRUE) {
+                current = newer;
+                attempt = 0;
+                continue;
+            }
+
+            xSemaphoreTake(udp_mutex, portMAX_DELAY);
+            int ret = sendto(udp_sock,
+                             &current, len, 0,
+                             (struct sockaddr *)&dest_addr,
+                             sizeof(dest_addr));
+            last_err = errno;
+            xSemaphoreGive(udp_mutex);
+            if (ret < 0) {
+                if (attempt == 1) {
+                    ESP_LOGW(TAG,
+                             "sendto failed (errno %d), retrying", last_err);
+                    init_udp_socket();
+                }
+                if ((xEventGroupGetBits(eg) & WIFI_CONNECTED_BIT) == 0 ||
+                    last_err == WIFI_SEND_ERR) {
+                    break;
+                }
+                vTaskDelay(pdMS_TO_TICKS(UDP_BASE_DELAY_MS << (attempt - 1)));
+            } else {
+                sent = true;
+                break;
+            }
+        }
+        if (!sent) {
+            if ((xEventGroupGetBits(eg) & WIFI_CONNECTED_BIT) == 0 ||
+                last_err == WIFI_SEND_ERR) {
+                ESP_LOGW(TAG, "Waiting for Wi-Fi to reconnect...");
+                xEventGroupWaitBits(eg,
+                                    WIFI_CONNECTED_BIT,
+                                    pdFALSE,
+                                    pdTRUE,
+                                    portMAX_DELAY);
+                ESP_LOGI(TAG, "Wi-Fi reconnected; re-initializing socket");
+                init_udp_socket();
+            } else {
+                ESP_LOGE(TAG,
+                         "Dropping packet after %d retries (errno %d)",
+                         UDP_MAX_RETRIES,
+                         last_err);
+            }
+        }
+
+        if (++heap_log_counter >= 1000) {
+            size_t free = heap_caps_get_free_size(MALLOC_CAP_DEFAULT);
+            ESP_LOGI(TAG, "Free heap: %lu bytes", (unsigned long)free);
+            heap_log_counter = 0;
+        }
+
+        vTaskDelay(pdMS_TO_TICKS(10));
+    }
+}

--- a/src/udp_sender/udp_sender.h
+++ b/src/udp_sender/udp_sender.h
@@ -1,0 +1,7 @@
+#ifndef UDP_SENDER_H
+#define UDP_SENDER_H
+
+void udp_sender_task(void *pvParameters);
+void udp_socket_close(void);
+
+#endif // UDP_SENDER_H

--- a/src/wifi_manager/wifi_manager.c
+++ b/src/wifi_manager/wifi_manager.c
@@ -180,3 +180,12 @@ esp_netif_ip_info_t wifi_get_ip_info(void)
     }
     return copy;
 }
+
+void wifi_force_reconnect(void)
+{
+    ESP_LOGW(TAG, "Forcing Wi-Fi reconnection");
+    esp_err_t err = esp_wifi_disconnect();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "esp_wifi_disconnect failed: %s", esp_err_to_name(err));
+    }
+}

--- a/src/wifi_manager/wifi_manager.h
+++ b/src/wifi_manager/wifi_manager.h
@@ -43,4 +43,9 @@ EventGroupHandle_t wifi_event_group(void);
  */
 esp_netif_ip_info_t wifi_get_ip_info(void);
 
+/**
+ * @brief Force a Wi-Fi disconnect so the manager will reconnect.
+ */
+void wifi_force_reconnect(void);
+
 #endif // WIFI_MANAGER_H


### PR DESCRIPTION
## Summary
- add telemetry configuration header
- add connectivity, MQTT sender and UDP sender components
- expose `wifi_force_reconnect` in wifi manager
- launch telemetry tasks from `app_main`

## Testing
- `idf.py --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870fb380ff08320b4efe09ae893ccfa